### PR TITLE
[REFACTOR] refreshToken 관리 관련 함수들 수정

### DIFF
--- a/next-vote/src/app/login/page.tsx
+++ b/next-vote/src/app/login/page.tsx
@@ -4,8 +4,11 @@ import Link from 'next/link';
 import { useState, FormEvent } from 'react';
 import { useAuth } from '@/hooks/auth/useAuth';
 import { loginSchema } from '@/schemas/loginSchema';
+import { useGuestGuard } from '@/hooks/useAuthGuard';
 
 const LoginPage = () => {
+  useGuestGuard(); // 이미 로그인한 사용자는 홈으로 리다이렉트
+
   const [loginId, setLoginId] = useState('');
   const [password, setPassword] = useState('');
   const [errors, setErrors] = useState<{ loginId?: string; password?: string }>({});

--- a/next-vote/src/app/members/page.tsx
+++ b/next-vote/src/app/members/page.tsx
@@ -1,4 +1,9 @@
+'use client';
+
+import { useLoginGuard } from '@/hooks/useAuthGuard';
+
 const MembersPage = () => {
+  useLoginGuard(); // 로그인하지 않은 사용자는 로그인 페이지로 리다이렉트
   return (
     <main className="min-h-screen flex items-center justify-center px-4 pt-20">
       <div className="text-center">

--- a/next-vote/src/app/signup/page.tsx
+++ b/next-vote/src/app/signup/page.tsx
@@ -1,8 +1,11 @@
-"use client";
+'use client';
 
-import SignUpForm from "../../components/signup/SignUpForm";
+import SignUpForm from '../../components/signup/SignUpForm';
+import { useGuestGuard } from '@/hooks/useAuthGuard';
 
 const SignUpPage = () => {
+  useGuestGuard();
+
   return (
     <div className="flex items-center justify-center gradient-radial pt-20">
       <SignUpForm />

--- a/next-vote/src/app/voting/page.tsx
+++ b/next-vote/src/app/voting/page.tsx
@@ -1,4 +1,9 @@
+'use client';
+
+import { useLoginGuard } from '@/hooks/useAuthGuard';
+
 const VotingPage = () => {
+  useLoginGuard(); // 로그인하지 않은 사용자는 로그인 페이지로 리다이렉트
   return (
     <main className="min-h-screen flex items-center justify-center px-4 pt-20">
       <div className="text-center">

--- a/next-vote/src/hooks/auth/useAuth.ts
+++ b/next-vote/src/hooks/auth/useAuth.ts
@@ -1,8 +1,8 @@
 'use client';
 
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
-import { login, logout, validateToken, refreshToken } from '@/lib/apis/auth';
+import { login, logout, refreshToken } from '@/lib/apis/auth';
 
 export const useAuth = () => {
   const router = useRouter();
@@ -30,13 +30,6 @@ export const useAuth = () => {
     },
   });
 
-  // 토큰 검증
-  const validateQuery = useQuery({
-    queryKey: ['validateToken'],
-    queryFn: validateToken,
-    enabled: false, // 수동 호출
-  });
-
   // 토큰 재발급
   const refreshMutation = useMutation({
     mutationFn: refreshToken,
@@ -45,11 +38,9 @@ export const useAuth = () => {
   return {
     login: loginMutation.mutate,
     logout: logoutMutation.mutate,
-    validateToken: validateQuery.refetch,
     refreshToken: refreshMutation.mutate,
     isLoginLoading: loginMutation.isPending,
     isLogoutLoading: logoutMutation.isPending,
-    isValidating: validateQuery.isFetching,
     isRefreshing: refreshMutation.isPending,
   };
 };

--- a/next-vote/src/hooks/useAuthGuard.ts
+++ b/next-vote/src/hooks/useAuthGuard.ts
@@ -1,0 +1,31 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+import { useEffect } from 'react';
+
+import { useAuthStore } from '@/stores/useAuthStore';
+
+export const useLoginGuard = (redirectTo: string = '/login') => {
+  const router = useRouter();
+  const { accessToken, isAuthChecked } = useAuthStore();
+
+  useEffect(() => {
+    if (!isAuthChecked) return;
+    if (!accessToken) {
+      router.replace(redirectTo);
+    }
+  }, [accessToken, isAuthChecked, router, redirectTo]);
+};
+
+export const useGuestGuard = (redirectTo: string = '/') => {
+  const router = useRouter();
+  const { accessToken, isAuthChecked } = useAuthStore();
+
+  useEffect(() => {
+    if (!isAuthChecked) return;
+    if (accessToken) {
+      router.replace(redirectTo);
+    }
+  }, [accessToken, isAuthChecked, router, redirectTo]);
+};

--- a/next-vote/src/lib/apis/axios.ts
+++ b/next-vote/src/lib/apis/axios.ts
@@ -1,22 +1,5 @@
 import { useAuthStore } from '@/stores/useAuthStore';
 import axios from 'axios';
-import type { RefreshResponse } from '@/types/auth/dto';
-
-// refreshTokenApi는 순환 참조를 피하기 위해 여기서 직접 정의
-// auth.ts의 refreshToken은 useAuth 훅에서 수동 호출용
-const refreshTokenApi = async (): Promise<string> => {
-  const response = await axios.post<RefreshResponse>(
-    `${process.env.NEXT_PUBLIC_API_URL}/api/auth/refresh`,
-    {},
-    { withCredentials: true },
-  );
-  const { accessToken } = response.data.result;
-  if (accessToken) {
-    useAuthStore.getState().setAccessToken(accessToken);
-    return accessToken;
-  }
-  throw new Error('No access token received');
-};
 
 // 해당 api는 인증 없이 접근 가능
 const NON_AUTH_URLS = [
@@ -52,11 +35,7 @@ axiosInstance.interceptors.request.use(
   (error) => Promise.reject(error),
 );
 
-// 토큰 재발급 상태 관리
-let isRefreshing = false;
-let failedQueue: Array<{ resolve: (value?: unknown) => void; reject: (reason?: unknown) => void }> = [];
-
-// Response Interceptor: 새 accessToken 자동 저장 및 401 에러 처리
+// Response Interceptor: 새 accessToken 자동 저장
 axiosInstance.interceptors.response.use(
   (response) => {
     const authHeader = response.headers['authorization'];
@@ -66,52 +45,7 @@ axiosInstance.interceptors.response.use(
     }
     return response;
   },
-  async (error) => {
-    const originalRequest = error.config;
-
-    // 401 에러이고, refresh 요청이 아닌 경우
-    if (
-      error.response?.status === 401 &&
-      !originalRequest._retry &&
-      !originalRequest.url?.includes('/api/auth/refresh')
-    ) {
-      if (isRefreshing) {
-        // 이미 refresh 중이면 대기
-        return new Promise((resolve, reject) => {
-          failedQueue.push({ resolve, reject });
-        }).then(() => axiosInstance(originalRequest));
-      }
-
-      originalRequest._retry = true;
-      isRefreshing = true;
-
-      try {
-        // refreshTokenApi 사용 (순환 참조 방지를 위해 직접 정의된 함수)
-        const accessToken = await refreshTokenApi();
-
-        // 새 토큰으로 원래 요청 재시도
-        originalRequest.headers.Authorization = `Bearer ${accessToken}`;
-
-        // 대기 중인 요청들 처리
-        failedQueue.forEach(({ resolve }) => resolve());
-        failedQueue = [];
-
-        return axiosInstance(originalRequest);
-      } catch (refreshError) {
-        // refresh 실패 시 로그인 페이지로
-        failedQueue.forEach(({ reject }) => reject(refreshError));
-        failedQueue = [];
-        useAuthStore.getState().clearAuth();
-
-        if (typeof window !== 'undefined') {
-          window.location.href = '/login';
-        }
-        return Promise.reject(refreshError);
-      } finally {
-        isRefreshing = false;
-      }
-    }
-
+  (error) => {
     return Promise.reject(error);
   },
 );

--- a/next-vote/src/providers/AuthProvider.tsx
+++ b/next-vote/src/providers/AuthProvider.tsx
@@ -1,37 +1,21 @@
 'use client';
 
 import { useEffect } from 'react';
-import { usePathname, useRouter } from 'next/navigation';
 import { useAuthStore } from '@/stores/useAuthStore';
-import { validateToken } from '@/lib/apis/auth';
+import { refreshToken } from '@/lib/apis/auth';
 
 export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
-  const pathname = usePathname();
-  const router = useRouter();
-  const { accessToken, clearAuth } = useAuthStore();
+  const setAuthChecked = useAuthStore((state) => state.setAuthChecked);
 
   useEffect(() => {
     const checkAuth = async () => {
-      // 로그인 페이지나 회원가입 페이지는 검증 스킵
-      if (pathname === '/login' || pathname === '/signup') {
-        return;
-      }
+      const skipAutoLogin = localStorage.getItem('skipAutoLogin') === 'true';
+      if (!skipAutoLogin) await refreshToken();
 
-      // 토큰이 있으면 검증
-      if (accessToken) {
-        try {
-          await validateToken();
-        } catch (error) {
-          // 토큰 유효하지 않으면 클리어하고 로그인 페이지로
-          clearAuth();
-          router.push('/login');
-        }
-      }
+      setAuthChecked();
     };
-
     checkAuth();
-  }, [pathname, accessToken, router, clearAuth]);
+  }, [setAuthChecked]);
 
   return <>{children}</>;
 };
-

--- a/next-vote/src/stores/useAuthStore.ts
+++ b/next-vote/src/stores/useAuthStore.ts
@@ -2,21 +2,31 @@ import { create } from 'zustand';
 
 interface AuthStore {
   accessToken: string;
+  isLoggedIn: boolean;
+  isAuthChecked: boolean;
 
   setAccessToken: (token: string) => void;
   clearAuth: () => void;
+  setAuthChecked: () => void;
 }
 
 export const useAuthStore = create<AuthStore>((set) => ({
   accessToken: '',
+  isLoggedIn: false,
+  isAuthChecked: false,
 
   setAccessToken: (token) =>
     set({
       accessToken: token,
+      isLoggedIn: true,
     }),
 
   clearAuth: () =>
     set({
       accessToken: '',
+      isLoggedIn: false,
+      isAuthChecked: true,
     }),
+
+  setAuthChecked: () => set({ isAuthChecked: true }),
 }));

--- a/next-vote/src/types/auth/dto.ts
+++ b/next-vote/src/types/auth/dto.ts
@@ -16,16 +16,6 @@ export interface LoginResponse {
   };
 }
 
-export interface ValidateResponse {
-  isSuccess: boolean;
-  code: string;
-  message: string;
-  result: {
-    message: string;
-    isValid: 'VALID' | 'INVALID';
-  };
-}
-
 export interface RefreshResponse {
   isSuccess: boolean;
   code: string;


### PR DESCRIPTION
## 🔥 작업 내용
- AuthProvider로 초기 화면 진입시 refreshToken으로 accessToken 재발급
- refresh api 에서 401에러 처리
- axios.ts에는 response에서 토큰 받아오는 로직만 구현
- Login guard, Guest Guard로 voting 페이지 등등 접근 제한 설정

## 🔗 관련 이슈
- #13 
